### PR TITLE
Get host problem id only if it is a host alert

### DIFF
--- a/notifications/derdack
+++ b/notifications/derdack
@@ -55,8 +55,8 @@ def get_text(context):
     contact_pager = context['CONTACTPAGER'].replace(' ', '')
     description = notification_type + ' on ' + host_name
     service_problem_id = ''
-    
-    host_problem_id = context['HOSTPROBLEMID']
+ 
+    host_problem_id = ''
     date_time = context['SHORTDATETIME']
 
     # Prepare Default information and Type PROBLEM, RECOVERY
@@ -72,6 +72,7 @@ def get_text(context):
             description += ' (' + service_desc + ')'
 
     else:
+        host_problem_id = context['HOSTPROBLEMID']
         if notification_type in [ "PROBLEM", "RECOVERY" ]:
             host_state = context['HOSTSTATE']
             description += ' (' + host_state + ')'


### PR DESCRIPTION
host_problem_id is not present e.g. if the alert comes from the event console, so we can only get it from the context variable if we're actually processing a Host problem. Tested on checkmk 2.0 at on of our checkmk/derdack customers.